### PR TITLE
Fix recharge rate edge case

### DIFF
--- a/src/core/energy_model.py
+++ b/src/core/energy_model.py
@@ -4,6 +4,9 @@
 import numpy as np
 from typing import Optional
 from dataclasses import dataclass
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -41,8 +44,13 @@ class EnergyModel:
         self.min_operational = params.min_operational
 
         # Compute derived parameters
-        self.full_recharge_time = self.capacity / self.recharge_rate
-        self.min_recharge_time = self.min_operational / self.recharge_rate
+        if self.recharge_rate > 0:
+            self.full_recharge_time = self.capacity / self.recharge_rate
+            self.min_recharge_time = self.min_operational / self.recharge_rate
+        else:
+            logger.warning("Recharge rate is non-positive; recharge times set to infinity")
+            self.full_recharge_time = float('inf')
+            self.min_recharge_time = float('inf')
 
         # Energy thresholds
         self.e_high = params.high_threshold * self.capacity
@@ -76,6 +84,10 @@ class EnergyModel:
 
         if current_energy >= target_energy:
             return 0.0
+
+        if self.recharge_rate <= 0:
+            logger.warning("Recharge rate is non-positive; time to recharge is infinite")
+            return float('inf')
 
         return (target_energy - current_energy) / self.recharge_rate
 

--- a/tests/test_energy_model.py
+++ b/tests/test_energy_model.py
@@ -97,6 +97,19 @@ class TestEnergyModel(unittest.TestCase):
         self.assertEqual(self.model.full_recharge_time, 100)  # 1000 / 10
         self.assertEqual(self.model.min_recharge_time, 10)   # 100 / 10
 
+    def test_zero_recharge_rate(self):
+        """Time to recharge should be infinite when recharge rate is zero."""
+        params = EnergyParameters(
+            capacity=100,
+            recharge_rate=0,
+            classification_cost=10,
+            min_operational=10
+        )
+        model = EnergyModel(params)
+
+        time = model.time_to_recharge(0, 50)
+        self.assertEqual(time, float('inf'))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle zero or negative recharge rate in EnergyModel
- guard against infinite recharge time
- test zero recharge rate behavior

## Testing
- `pytest tests/test_camera.py tests/test_energy_model.py tests/test_accuracy_model.py -q`
- `pytest tests/test_energy_model.py::TestEnergyModel::test_zero_recharge_rate -q`


------
https://chatgpt.com/codex/tasks/task_e_684062370444832fab1696bf8b5d43e5