### PR TITLE
Fix energy check in camera selection

### DIFF
--- a/src/core/enhanced_accuracy_model.py
+++ b/src/core/enhanced_accuracy_model.py
@@ -208,7 +208,7 @@ class EnhancedAccuracyModel(AccuracyModel):
         # Score each camera by accuracy per unit energy
         scores = []
         for i, cam in enumerate(cameras):
-            if cam.energy >= self.min_operational:
+            if cam.current_energy >= self.min_operational:
                 accuracy = self.get_position_based_accuracy(cam, object_position)
                 efficiency = accuracy / cam.energy_model.classification_cost
                 scores.append((i, efficiency, accuracy))


### PR DESCRIPTION
## Summary
- check `current_energy` in `optimal_camera_selection`

## Testing
- `python -m pytest tests/test_energy_model.py tests/test_accuracy_model.py tests/test_camera.py tests/test_algorithms.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840655d6824832fb25540347eb0ba36