### PR TITLE
Fix f-string formatting in scenario tests

### DIFF
--- a/tests/scenarios/test_edge_cases.py
+++ b/tests/scenarios/test_edge_cases.py
@@ -309,8 +309,10 @@ def generate_edge_case_report(all_results, output_dir):
                     f.write(f"  Energy Violations: {stats.get('energy_violations', 0)}\n")
                     f.write(f"  Accuracy Violations: {stats.get('accuracy_violations', 0)}\n")
                     f.write(f"  Total Classifications: {stats.get('total_classifications', 0)}\n")
-                    f.write(f"  Success Rate: {stats.get('successful_classifications', 0)/"
-                           f"{max(1, stats.get('total_classifications', 1)):.1%}\n")
+                    f.write(
+                        f"  Success Rate: "
+                        f"{stats.get('successful_classifications', 0) / max(1, stats.get('total_classifications', 1)):.1%}\n"
+                    )
         
         f.write("\n" + "="*80 + "\n")
         f.write("KEY FINDINGS:\n")

--- a/tests/scenarios/test_stress.py
+++ b/tests/scenarios/test_stress.py
@@ -171,8 +171,10 @@ def run_stress_test(test_name, config, test_params, output_dir):
             print(f"    Execution time: {performance_metrics[algo]['execution_time']:.2f}s")
             print(f"    Memory usage: {mem_before:.1f}MB -> {mem_after:.1f}MB "
                   f"(+{performance_metrics[algo]['memory_increase']:.1f}MB)")
-            print(f"    Events/second: {performance_metrics[algo]['total_events'] / "
-                  f"performance_metrics[algo]['execution_time']:.2f}")
+            print(
+                f"    Events/second: "
+                f"{performance_metrics[algo]['total_events'] / performance_metrics[algo]['execution_time']:.2f}"
+            )
             print(f"    Accuracy: {result['network_stats']['accuracy']:.3f}")
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- fix multi-line f-string for success rate in edge case tests
- fix events/second f-string in stress tests

## Testing
- `python -m py_compile tests/scenarios/test_edge_cases.py`
- `python -m py_compile tests/scenarios/test_stress.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68406a9632c8832f98e38991967cf7ba