### PR TITLE
Optimize distance calculations

### DIFF
--- a/src/algorithms/enhanced_base_algorithm.py
+++ b/src/algorithms/enhanced_base_algorithm.py
@@ -202,7 +202,10 @@ class EnhancedBaseClassificationAlgorithm(BaseClassificationAlgorithm):
         return result
     
     def _calculate_enhanced_collective_accuracy(
-        self, cameras: List[Camera], object_position: np.ndarray
+        self,
+        cameras: List[Camera],
+        object_position: np.ndarray,
+        distances: Optional[np.ndarray] = None
     ) -> float:
         """Calculate collective accuracy with position awareness."""
         if not cameras or not self.using_enhanced:
@@ -211,7 +214,7 @@ class EnhancedBaseClassificationAlgorithm(BaseClassificationAlgorithm):
         # Use enhanced accuracy model
         accuracy_model = cameras[0].accuracy_model
         return accuracy_model.get_collective_accuracy_with_positions(
-            cameras, object_position
+            cameras, object_position, distances=distances
         )
     
     def get_optimal_camera_count(

--- a/src/algorithms/enhanced_fixed_frequency.py
+++ b/src/algorithms/enhanced_fixed_frequency.py
@@ -150,7 +150,7 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
             # Standard greedy selection
             return self._select_greedy(class_cameras)
     
-    def _select_position_aware(self, candidate_cameras: List[int], 
+    def _select_position_aware(self, candidate_cameras: List[int],
                                object_position: np.ndarray) -> List[int]:
         """
         Position-aware camera selection.
@@ -165,28 +165,37 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
         if not self.using_enhanced:
             return self._select_greedy(candidate_cameras)
             
+        # Precompute distances to all candidate cameras
+        positions = np.array([self.cameras[i].position for i in candidate_cameras])
+        distances = np.linalg.norm(positions - object_position, axis=1)
+        distance_map = {cid: d for cid, d in zip(candidate_cameras, distances)}
+
         # Score cameras by position and energy
         camera_scores = []
-        
+
         for cam_id in candidate_cameras:
             camera = self.cameras[cam_id]
-            
+
             if not camera.can_classify():
                 continue
-                
+
+            dist = distance_map[cam_id]
+
             # Calculate position-based accuracy
             pos_accuracy = camera.accuracy_model.get_position_based_accuracy(
-                camera, object_position
+                camera, object_position, precomputed_distance=dist
             )
-            
+
             # Energy factor
             energy_factor = camera.current_energy / camera.energy_model.capacity
-            
+
             # Combined score
-            score = (self.position_weight * pos_accuracy + 
-                    (1 - self.position_weight) * energy_factor)
-            
-            camera_scores.append((cam_id, score, pos_accuracy))
+            score = (
+                self.position_weight * pos_accuracy
+                + (1 - self.position_weight) * energy_factor
+            )
+
+            camera_scores.append((cam_id, score, dist))
         
         # Sort by score
         camera_scores.sort(key=lambda x: x[1], reverse=True)
@@ -194,13 +203,14 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
         # Select cameras to meet accuracy threshold
         selected = []
         
-        for cam_id, score, _ in camera_scores:
+        for cam_id, score, dist in camera_scores:
             selected.append(cam_id)
-            
+
             # Check if accuracy threshold met
             selected_cameras = [self.cameras[i] for i in selected]
+            selected_distances = np.array([distance_map[i] for i in selected])
             collective_accuracy = self._calculate_enhanced_collective_accuracy(
-                selected_cameras, object_position
+                selected_cameras, object_position, selected_distances
             )
             
             if collective_accuracy >= self.min_accuracy_threshold:
@@ -223,18 +233,25 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
         if not self.using_enhanced:
             return self._select_greedy(candidate_cameras)
             
+        # Precompute distances
+        positions = np.array([self.cameras[i].position for i in candidate_cameras])
+        distances = np.linalg.norm(positions - object_position, axis=1)
+        distance_map = {cid: d for cid, d in zip(candidate_cameras, distances)}
+
         # Calculate utilities for each camera
         camera_utilities = []
-        
+
         for cam_id in candidate_cameras:
             camera = self.cameras[cam_id]
-            
+
             if not camera.can_classify():
                 continue
-                
+
+            dist = distance_map[cam_id]
+
             # Position-based accuracy
             accuracy = camera.accuracy_model.get_position_based_accuracy(
-                camera, object_position
+                camera, object_position, precomputed_distance=dist
             )
             
             # Expected reward
@@ -260,7 +277,7 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
         selected = []
         remaining_budget = len(candidate_cameras) * 50  # Energy budget
         
-        for cam_id, utility, accuracy in camera_utilities:
+        for cam_id, utility, _ in camera_utilities:
             camera = self.cameras[cam_id]
             
             if camera.energy_model.classification_cost <= remaining_budget:
@@ -269,8 +286,9 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
                 
                 # Check accuracy with current selection
                 selected_cameras = [self.cameras[i] for i in selected]
+                selected_distances = np.array([distance_map[i] for i in selected])
                 collective_accuracy = self._calculate_enhanced_collective_accuracy(
-                    selected_cameras, object_position
+                    selected_cameras, object_position, selected_distances
                 )
                 
                 if collective_accuracy >= self.min_accuracy_threshold:
@@ -281,10 +299,11 @@ class EnhancedFixedFrequencyAlgorithm(EnhancedBaseClassificationAlgorithm):
             for cam_id, _, _ in camera_utilities:
                 if cam_id not in selected:
                     selected.append(cam_id)
-                    
+
                     selected_cameras = [self.cameras[i] for i in selected]
+                    selected_distances = np.array([distance_map[i] for i in selected])
                     collective_accuracy = self._calculate_enhanced_collective_accuracy(
-                        selected_cameras, object_position
+                        selected_cameras, object_position, selected_distances
                     )
                     
                     if collective_accuracy >= self.min_accuracy_threshold:

--- a/tests/test_enhanced_fixed_frequency.py
+++ b/tests/test_enhanced_fixed_frequency.py
@@ -1,0 +1,94 @@
+import unittest
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.core.camera import Camera
+from src.core.energy_model import EnergyModel, EnergyParameters
+from src.core.enhanced_accuracy_model import EnhancedAccuracyModel, EnhancedAccuracyParameters
+from src.algorithms.enhanced_fixed_frequency import EnhancedFixedFrequencyAlgorithm
+
+
+class TestEnhancedFixedFrequencyPrecompute(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(42)
+        energy_params = EnergyParameters(
+            capacity=1000,
+            recharge_rate=10,
+            classification_cost=50,
+            min_operational=100,
+        )
+        energy_model = EnergyModel(energy_params)
+        acc_params = EnhancedAccuracyParameters(
+            max_accuracy=0.9,
+            min_accuracy_ratio=0.3,
+            correlation_factor=0.0,
+        )
+        accuracy_model = EnhancedAccuracyModel(acc_params, energy_model)
+
+        self.cameras = []
+        positions = [
+            np.array([0, 0, 0]),
+            np.array([10, 0, 0]),
+            np.array([0, 10, 0]),
+            np.array([10, 10, 0]),
+        ]
+        for i, pos in enumerate(positions):
+            cam = Camera(
+                camera_id=i,
+                position=pos,
+                energy_model=energy_model,
+                accuracy_model=accuracy_model,
+                initial_energy=800,
+            )
+            cam.class_assignment = i % 2
+            self.cameras.append(cam)
+
+        self.algorithm = EnhancedFixedFrequencyAlgorithm(
+            cameras=self.cameras,
+            num_classes=2,
+            min_accuracy_threshold=0.5,
+            use_game_theory=False,
+            position_weight=0.7,
+        )
+
+    def baseline_select(self, candidate_cameras, object_position):
+        camera_scores = []
+        for cid in candidate_cameras:
+            cam = self.cameras[cid]
+            if not cam.can_classify():
+                continue
+            pos_acc = cam.accuracy_model.get_position_based_accuracy(cam, object_position)
+            energy_factor = cam.current_energy / cam.energy_model.capacity
+            score = 0.7 * pos_acc + 0.3 * energy_factor
+            camera_scores.append((cid, score))
+        camera_scores.sort(key=lambda x: x[1], reverse=True)
+        selected = []
+        for cid, _ in camera_scores:
+            selected.append(cid)
+            cams = [self.cameras[i] for i in selected]
+            acc = self.algorithm._calculate_enhanced_collective_accuracy(cams, object_position)
+            if acc >= self.algorithm.min_accuracy_threshold:
+                break
+        return selected
+
+    def test_precomputed_distance_consistency(self):
+        obj_pos = np.array([5, 5, 0])
+        class_id = 0
+        candidates = self.algorithm.camera_classes[class_id]
+
+        expected = self.baseline_select(candidates, obj_pos)
+        result = self.algorithm.select_cameras(class_id, 0.0, obj_pos)
+        self.assertEqual(expected, result)
+
+        selected_cams = [self.cameras[i] for i in result]
+        distances = np.linalg.norm([cam.position for cam in selected_cams] - obj_pos, axis=1)
+        acc1 = self.algorithm._calculate_enhanced_collective_accuracy(selected_cams, obj_pos, distances)
+        acc2 = self.algorithm._calculate_enhanced_collective_accuracy(selected_cams, obj_pos)
+        self.assertAlmostEqual(acc1, acc2, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- vectorize distance operations in `EnhancedFixedFrequencyAlgorithm`
- allow passing cached distances to enhanced accuracy helpers
- add regression test for precomputed distance logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68407614ad00832f9c0d11bc6e0e5546